### PR TITLE
Fix HiDPI overlay coordinate handling

### DIFF
--- a/src/heartopia_painter/hidpi.py
+++ b/src/heartopia_painter/hidpi.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import Iterable, Optional, Tuple, Union
+
+from PySide6 import QtCore, QtGui
+
+
+PointLike = Union[QtCore.QPoint, QtCore.QPointF, Tuple[float, float], Tuple[int, int], Iterable[float]]
+RectTuple = Tuple[int, int, int, int]
+
+
+def _as_pointf(value: PointLike) -> QtCore.QPointF:
+    if isinstance(value, QtCore.QPointF):
+        return QtCore.QPointF(value)
+    if isinstance(value, QtCore.QPoint):
+        return QtCore.QPointF(value)
+    try:
+        x, y = value  # type: ignore[misc]
+        return QtCore.QPointF(float(x), float(y))
+    except Exception:
+        return QtCore.QPointF(0.0, 0.0)
+
+
+def _screen_for_logical_point(pt: QtCore.QPointF) -> Optional[QtGui.QScreen]:
+    qpoint = QtCore.QPoint(int(round(pt.x())), int(round(pt.y())))
+    screen = QtGui.QGuiApplication.screenAt(qpoint)
+    if screen is not None:
+        return screen
+    return QtGui.QGuiApplication.primaryScreen()
+
+
+def _screen_for_native_point(pt: QtCore.QPointF) -> Optional[QtGui.QScreen]:
+    qpoint = QtCore.QPoint(int(round(pt.x())), int(round(pt.y())))
+    for screen in QtGui.QGuiApplication.screens():
+        native_geo = screen.nativeGeometry()
+        if native_geo.contains(qpoint):
+            return screen
+    return QtGui.QGuiApplication.primaryScreen()
+
+
+def logical_point_to_native(point: PointLike) -> QtCore.QPoint:
+    pt = _as_pointf(point)
+    screen = _screen_for_logical_point(pt)
+    if screen is None:
+        return QtCore.QPoint(int(round(pt.x())), int(round(pt.y())))
+
+    geo = screen.geometry()
+    native_geo = screen.nativeGeometry()
+    if geo.width() <= 0 or geo.height() <= 0:
+        return QtCore.QPoint(int(round(pt.x())), int(round(pt.y())))
+
+    rel_x = pt.x() - geo.x()
+    rel_y = pt.y() - geo.y()
+
+    scale_x = native_geo.width() / max(1.0, float(geo.width()))
+    scale_y = native_geo.height() / max(1.0, float(geo.height()))
+
+    native_x = native_geo.x() + rel_x * scale_x
+    native_y = native_geo.y() + rel_y * scale_y
+    return QtCore.QPoint(int(round(native_x)), int(round(native_y)))
+
+
+def native_point_to_logical(point: PointLike) -> QtCore.QPointF:
+    pt = _as_pointf(point)
+    screen = _screen_for_native_point(pt)
+    if screen is None:
+        return QtCore.QPointF(pt)
+
+    geo = screen.geometry()
+    native_geo = screen.nativeGeometry()
+    if native_geo.width() <= 0 or native_geo.height() <= 0:
+        return QtCore.QPointF(pt)
+
+    rel_x = pt.x() - native_geo.x()
+    rel_y = pt.y() - native_geo.y()
+
+    inv_scale_x = geo.width() / max(1.0, float(native_geo.width()))
+    inv_scale_y = geo.height() / max(1.0, float(native_geo.height()))
+
+    logical_x = geo.x() + rel_x * inv_scale_x
+    logical_y = geo.y() + rel_y * inv_scale_y
+    return QtCore.QPointF(logical_x, logical_y)
+
+
+def logical_rect_to_native(rect: Union[QtCore.QRect, QtCore.QRectF]) -> QtCore.QRect:
+    r = QtCore.QRectF(rect)
+    top_left = logical_point_to_native(r.topLeft())
+    bottom_right_logical = QtCore.QPointF(r.left() + r.width(), r.top() + r.height())
+    bottom_right = logical_point_to_native(bottom_right_logical)
+    native = QtCore.QRect(top_left, bottom_right)
+    native = native.normalized()
+    return native
+
+
+def native_rect_tuple_to_logical(rect: RectTuple) -> QtCore.QRectF:
+    left, top, right, bottom = rect
+    top_left = native_point_to_logical((left, top))
+    bottom_right = native_point_to_logical((right, bottom))
+    size = QtCore.QSizeF(bottom_right.x() - top_left.x(), bottom_right.y() - top_left.y())
+    logical = QtCore.QRectF(top_left, size)
+    return logical.normalized()

--- a/src/heartopia_painter/hidpi.py
+++ b/src/heartopia_painter/hidpi.py
@@ -9,6 +9,39 @@ PointLike = Union[QtCore.QPoint, QtCore.QPointF, Tuple[float, float], Tuple[int,
 RectTuple = Tuple[int, int, int, int]
 
 
+def _screen_device_pixel_ratio(screen: QtGui.QScreen) -> float:
+    try:
+        dpr = float(screen.devicePixelRatio())
+    except Exception:
+        dpr = 1.0
+    if dpr <= 0 or not float(dpr):
+        return 1.0
+    return dpr
+
+
+def _screen_native_geometry(screen: QtGui.QScreen) -> QtCore.QRect:
+    native_geo = None
+    try:
+        native_geo_attr = getattr(screen, "nativeGeometry", None)
+        if callable(native_geo_attr):
+            native_geo = native_geo_attr()
+    except Exception:
+        native_geo = None
+    if isinstance(native_geo, QtCore.QRect):
+        return native_geo
+
+    geo = QtCore.QRect(screen.geometry())
+    dpr = _screen_device_pixel_ratio(screen)
+    if abs(dpr - 1.0) < 1e-6:
+        return geo
+    return QtCore.QRect(
+        int(round(geo.x() * dpr)),
+        int(round(geo.y() * dpr)),
+        int(round(geo.width() * dpr)),
+        int(round(geo.height() * dpr)),
+    )
+
+
 def _as_pointf(value: PointLike) -> QtCore.QPointF:
     if isinstance(value, QtCore.QPointF):
         return QtCore.QPointF(value)
@@ -32,7 +65,7 @@ def _screen_for_logical_point(pt: QtCore.QPointF) -> Optional[QtGui.QScreen]:
 def _screen_for_native_point(pt: QtCore.QPointF) -> Optional[QtGui.QScreen]:
     qpoint = QtCore.QPoint(int(round(pt.x())), int(round(pt.y())))
     for screen in QtGui.QGuiApplication.screens():
-        native_geo = screen.nativeGeometry()
+        native_geo = _screen_native_geometry(screen)
         if native_geo.contains(qpoint):
             return screen
     return QtGui.QGuiApplication.primaryScreen()
@@ -45,7 +78,7 @@ def logical_point_to_native(point: PointLike) -> QtCore.QPoint:
         return QtCore.QPoint(int(round(pt.x())), int(round(pt.y())))
 
     geo = screen.geometry()
-    native_geo = screen.nativeGeometry()
+    native_geo = _screen_native_geometry(screen)
     if geo.width() <= 0 or geo.height() <= 0:
         return QtCore.QPoint(int(round(pt.x())), int(round(pt.y())))
 
@@ -67,7 +100,7 @@ def native_point_to_logical(point: PointLike) -> QtCore.QPointF:
         return QtCore.QPointF(pt)
 
     geo = screen.geometry()
-    native_geo = screen.nativeGeometry()
+    native_geo = _screen_native_geometry(screen)
     if native_geo.width() <= 0 or native_geo.height() <= 0:
         return QtCore.QPointF(pt)
 

--- a/src/heartopia_painter/overlay.py
+++ b/src/heartopia_painter/overlay.py
@@ -6,6 +6,13 @@ from typing import List, Optional, Tuple
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
+from .hidpi import (
+    logical_point_to_native,
+    logical_rect_to_native,
+    native_point_to_logical,
+    native_rect_tuple_to_logical,
+)
+
 
 @dataclass
 class RectResult:
@@ -116,12 +123,13 @@ class RectSelectOverlay(QtWidgets.QWidget):
                 self.hide()
                 # Convert back to global screen coordinates for downstream clicking.
                 global_rect = rect.translated(self._global_origin)
+                native_rect = logical_rect_to_native(global_rect)
                 self.rectSelected.emit(
                     RectResult(
-                        x=global_rect.x(),
-                        y=global_rect.y(),
-                        w=global_rect.width(),
-                        h=global_rect.height(),
+                        x=native_rect.x(),
+                        y=native_rect.y(),
+                        w=native_rect.width(),
+                        h=native_rect.height(),
                     )
                 )
             else:
@@ -292,8 +300,9 @@ class PointSelectOverlay(QtWidgets.QWidget):
         if event.button() == QtCore.Qt.MouseButton.LeftButton:
             local = event.position().toPoint()
             global_pt = local + self._global_origin
+            native_pt = logical_point_to_native(global_pt)
             self.hide()
-            self.pointSelected.emit(PointResult(x=global_pt.x(), y=global_pt.y()))
+            self.pointSelected.emit(PointResult(x=native_pt.x(), y=native_pt.y()))
             return
         if event.button() == QtCore.Qt.MouseButton.RightButton:
             self.hide()
@@ -414,16 +423,18 @@ class MarkersOverlay(QtWidgets.QWidget):
 
         # Markers
         radius = 12
+        origin_f = QtCore.QPointF(self._global_origin)
         for m in self._markers:
             gx, gy = int(m.pos[0]), int(m.pos[1])
-            local = QtCore.QPoint(gx, gy) - self._global_origin
+            logical_pt = native_point_to_logical((gx, gy))
+            local = logical_pt - origin_f
 
             col = QtGui.QColor(int(m.color[0]), int(m.color[1]), int(m.color[2]), 255)
             pen = QtGui.QPen(col)
             pen.setWidth(3)
             painter.setPen(pen)
             painter.setBrush(QtGui.QColor(col.red(), col.green(), col.blue(), 30))
-            painter.drawEllipse(local, radius, radius)
+            painter.drawEllipse(QtCore.QPointF(local), radius, radius)
 
             # Crosshair
             painter.drawLine(local.x() - 18, local.y(), local.x() + 18, local.y())
@@ -435,7 +446,7 @@ class MarkersOverlay(QtWidgets.QWidget):
             tw = fm.horizontalAdvance(label)
             th = fm.height()
             pad = 6
-            box = QtCore.QRect(local.x() + 18, local.y() - th, tw + pad * 2, th + pad)
+            box = QtCore.QRectF(local.x() + 18, local.y() - th, tw + pad * 2, th + pad)
             painter.setPen(QtCore.Qt.PenStyle.NoPen)
             painter.setBrush(QtGui.QColor(0, 0, 0, 175))
             painter.drawRoundedRect(box, 6, 6)
@@ -463,7 +474,7 @@ class StatusOverlay(QtWidgets.QWidget):
 
         self._title = str(title)
         self._status: str = "Idle"
-        self._anchor_rect: Optional[QtCore.QRect] = None
+        self._anchor_rect: Optional[QtCore.QRectF] = None
 
         # Replica canvas state (grid coords)
         self._grid_w: int = 0
@@ -566,7 +577,7 @@ class StatusOverlay(QtWidgets.QWidget):
             self._anchor_rect = None
             return
         l, t, r, b = (int(rect[0]), int(rect[1]), int(rect[2]), int(rect[3]))
-        self._anchor_rect = QtCore.QRect(l, t, max(0, r - l), max(0, b - t))
+        self._anchor_rect = native_rect_tuple_to_logical((l, t, r, b))
         self._reposition_to_anchor()
 
     def _reposition_to_anchor(self) -> None:
@@ -582,7 +593,7 @@ class StatusOverlay(QtWidgets.QWidget):
         # Clamp vertically so we never go above the window.
         y = max(ar.top() + margin, y)
 
-        self.move(int(x), int(y))
+        self.move(int(round(x)), int(round(y)))
 
     def _apply_platform_clickthrough(self) -> None:
         if os.name != "nt":


### PR DESCRIPTION
## Summary
- fix overlay rectangle coordinate mapping on HiDPI displays
- account for device pixel ratio when translating preview coordinates
- add nativeGeometry fallback for older PySide versions

## Testing
- manually verified with user playtesting on affected HiDPI setups